### PR TITLE
Preventing spurious updates of Input elements

### DIFF
--- a/WebSharper.UI.Next/Doc.fs
+++ b/WebSharper.UI.Next/Doc.fs
@@ -444,7 +444,7 @@ type Doc with
             | TextArea -> (Attr.Concat attr, "textarea")
         let el = DU.CreateElement elemTy
         let view = View.FromVar var
-        let valAttr = Attr.DynamicCustom (fun el v -> el?value <- v) view
+        let valAttr = Attr.DynamicCustom (fun el v -> if el?value <> v then el?value <- v) view
         let onChange (x: DomEvent) =
             Var.Set var el?value
         el.AddEventListener("input", onChange, false)


### PR DESCRIPTION
Input elements get updated whenever the text changes, even if their content is up to date.

This has undesirable side effects: e.g. for text input elements the cursor gets pushed to the end of the text, effectively preventing one from inserting new text at any place other than the end of input.