### PR TITLE
Snap and View.MapCached

### DIFF
--- a/WebSharper.UI.Next/Reactive.fs
+++ b/WebSharper.UI.Next/Reactive.fs
@@ -126,6 +126,11 @@ type View =
         View.CreateLazy (fun () ->
             observe () |> Snap.Map fn)
 
+    static member MapCached fn (V observe) =
+        let vref = ref None
+        View.CreateLazy (fun () ->
+            observe () |> Snap.MapCached vref fn)
+
     // Creates a lazy view using a given snap function and 2 views
     static member private CreateLazy2 snapFn (V o1) (V o2) =
         View.CreateLazy (fun () ->

--- a/WebSharper.UI.Next/Reactive.fsi
+++ b/WebSharper.UI.Next/Reactive.fsi
@@ -99,6 +99,10 @@ type View =
     /// Lifting functions.
     static member Map : ('A -> 'B) -> View<'A> -> View<'B>
 
+    /// Lift a function, doesn't call it again if the input value is equal to the previous one.
+    static member MapCached : ('A -> 'B) -> View<'A> -> View<'B>
+        when 'A : equality
+
     /// Lifting async functions.
     static member MapAsync : ('A -> Async<'B>) -> View<'A> -> View<'B>
 

--- a/WebSharper.UI.Next/Snap.fs
+++ b/WebSharper.UI.Next/Snap.fs
@@ -147,6 +147,16 @@ module Snap =
             When sn (fn >> MarkDone res sn) (fun () -> MarkObsolete res)
             res
 
+    let MapCached prev fn sn =
+        let fn x =
+            match !prev with
+            | Some (x', y) when x = x' -> y
+            | _ ->
+                let y = fn x
+                prev := Some (x, y)
+                y
+        Map fn sn
+
     let Map2 fn sn1 sn2 =
         match sn1.State, sn2.State with
         | Forever x, Forever y -> CreateForever (fn x y) // optimization

--- a/WebSharper.UI.Next/Snap.fsi
+++ b/WebSharper.UI.Next/Snap.fsi
@@ -48,6 +48,9 @@ module internal Snap =
     /// Maps a function.
     val Map : ('A -> 'B) -> Snap<'A> -> Snap<'B>
 
+    val internal MapCached : ref<option<'A * 'B>> -> ('A -> 'B) -> Snap<'A> -> Snap<'B>
+        when 'A : equality
+
     /// Combines two snaps.
     val Map2 : ('A -> 'B -> 'C) -> Snap<'A> -> Snap<'B> -> Snap<'C>
 


### PR DESCRIPTION
Useful when the mapping function is expensive, see #35 for a use case.

Note that there are still as many changes propagated through the graph as with `Map`; only the value to propagate is cached.

Unfortunately it is not possible to completely avoid propagating the change. When we receive an obsolete message, the upstream snap is in an Obsolete state (by definition). We don't know yet if the next value will be the same or not, so we can't decide yet whether to propagate the obsolete message or not.