### PR TITLE
Add View.Convert, Doc.Convert as extension methods

### DIFF
--- a/WebSharper.UI.Next.Templating/WebSharper.UI.Next.Templating.fsproj
+++ b/WebSharper.UI.Next.Templating/WebSharper.UI.Next.Templating.fsproj
@@ -3,14 +3,30 @@
   <PropertyGroup>
     <ProjectGuid>{f2f67741-6877-412e-a4b6-2ebd8dfed8a6}</ProjectGuid>
     <Name>WebSharper.UI.Next.Templating</Name>
+    <RootNamespace>$(Name)</RootNamespace>
+    <AssemblyName>$(Name)</AssemblyName>
     <WebSharperProject>Library</WebSharperProject>
     <OutputType>Library</OutputType>
     <OutputPath>../build/net40</OutputPath>
+    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
+  <!-- F# targets -->
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
   <Import Project="../build/net40/$(Name).proj" />
-  <Import Project="../msbuild/FSharp.targets" />
   <ItemGroup>
     <Compile Include="ProvidedTypes.fsi" />
     <Compile Include="ProvidedTypes.fs" />

--- a/WebSharper.UI.Next.Tests/Client.fs
+++ b/WebSharper.UI.Next.Tests/Client.fs
@@ -45,7 +45,7 @@ module Client =
                     ] [textView title]
                 ],
                 ListContainer = [
-                    myItems.View.Doc(Item.Key, fun key item ->
+                    myItems.View.DocSeqCached(Item.Key, fun key item ->
                         MyTemplate.ListItem.Doc(
                             Name = item.Map(fun i -> i.name),
                             Description = myItems.LensInto (fun i -> i.description) (fun i d -> { i with description = d }) key,
@@ -55,7 +55,7 @@ module Client =
                 ],
                 SubmitItems = (fun el ev -> itemsSub.Trigger ()),
                 ListView = [
-                    itemsSub.View.Doc(Item.Key, fun key item ->
+                    itemsSub.View.DocSeqCached(Item.Key, fun key item ->
                         MyTemplate.ListViewItem.Doc(
                             Name = item.Map(fun i -> i.name),
                             Description = item.Map(fun i -> i.description)

--- a/WebSharper.UI.Next.Tests/Client.fs
+++ b/WebSharper.UI.Next.Tests/Client.fs
@@ -45,7 +45,7 @@ module Client =
                     ] [textView title]
                 ],
                 ListContainer = [
-                    myItems.View |> Doc.ConvertSeqBy Item.Key (fun key item ->
+                    myItems.View.Doc(Item.Key, fun key item ->
                         MyTemplate.ListItem.Doc(
                             Name = item.Map(fun i -> i.name),
                             Description = myItems.LensInto (fun i -> i.description) (fun i d -> { i with description = d }) key,
@@ -55,7 +55,7 @@ module Client =
                 ],
                 SubmitItems = (fun el ev -> itemsSub.Trigger ()),
                 ListView = [
-                    itemsSub.View |> Doc.ConvertSeqBy Item.Key (fun key item ->
+                    itemsSub.View.Doc(Item.Key, fun key item ->
                         MyTemplate.ListViewItem.Doc(
                             Name = item.Map(fun i -> i.name),
                             Description = item.Map(fun i -> i.description)

--- a/WebSharper.UI.Next.Tests/WebSharper.UI.Next.Tests.fsproj
+++ b/WebSharper.UI.Next.Tests/WebSharper.UI.Next.Tests.fsproj
@@ -4,10 +4,13 @@
     <ProjectGuid>{608521d3-89cf-452b-ad62-5fa7eb246e6f}</ProjectGuid>
     <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{F2A71F9B-5D33-465A-A702-920D77279786}</ProjectTypeGuids>
     <Name>WebSharper.UI.Next.Tests</Name>
+    <RootNamespace>$(Name)</RootNamespace>
+    <AssemblyName>$(Name)</AssemblyName>
     <WebSharperProject>Bundle</WebSharperProject>
     <WebSharperBundleOutputDir>Content</WebSharperBundleOutputDir>
     <OutputType>Library</OutputType>
     <OutputPath>bin</OutputPath>
+    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />
@@ -15,8 +18,21 @@
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
   </PropertyGroup>
+  <!-- F# targets -->
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
   <Import Project="../build/net40/$(Name).proj" />
-  <Import Project="../msbuild/FSharp.targets" />
   <ItemGroup>
     <Compile Include="Client.fs" />
     <Compile Include="Main.fs" />

--- a/WebSharper.UI.Next/Doc.Client.fs
+++ b/WebSharper.UI.Next/Doc.Client.fs
@@ -542,19 +542,19 @@ type [<Proxy(typeof<Doc>); CompiledName "Doc">]
 
     [<JavaScript>]
     static member Convert render view =
-        View.Convert render view |> Doc'.Flatten
+        View.MapSeqCached render view |> Doc'.Flatten
 
     [<JavaScript>]
     static member ConvertBy key render view =
-        View.ConvertBy key render view |> Doc'.Flatten
+        View.MapSeqCachedBy key render view |> Doc'.Flatten
 
     [<JavaScript>]
     static member ConvertSeq render view =
-        View.ConvertSeq render view |> Doc'.Flatten
+        View.MapSeqCachedView render view |> Doc'.Flatten
 
     [<JavaScript>]
     static member ConvertSeqBy key render view =
-        View.ConvertSeqBy key (As render) view |> Doc'.Flatten
+        View.MapSeqCachedViewBy key (As render) view |> Doc'.Flatten
 
     [<JavaScript>]
     static member InputInternal elemTy attr =
@@ -1390,20 +1390,32 @@ module Doc =
   // Collections ----------------------------------------------------------------
 
     [<Inline>]
-    let Convert (render: 'T -> #Doc) (view: View<seq<'T>>) : Doc =
+    let BindSeqCached (render: 'T -> #Doc) (view: View<seq<'T>>) : Doc =
         As (Doc'.Convert (As render) view)
 
     [<Inline>]
-    let ConvertBy (key: 'T -> 'K) (render: 'T -> #Doc) (view: View<seq<'T>>) : Doc =
+    let Convert f v = BindSeqCached f v
+
+    [<Inline>]
+    let BindSeqCachedBy (key: 'T -> 'K) (render: 'T -> #Doc) (view: View<seq<'T>>) : Doc =
         As (Doc'.ConvertBy key (As render) view)
 
     [<Inline>]
-    let ConvertSeq (render: View<'T> -> #Doc) (view: View<seq<'T>>) : Doc =
+    let ConvertBy k f v = BindSeqCachedBy k f v
+
+    [<Inline>]
+    let BindSeqCachedView (render: View<'T> -> #Doc) (view: View<seq<'T>>) : Doc =
         As (Doc'.ConvertSeq (As render) view)
 
     [<Inline>]
-    let ConvertSeqBy (key: 'T -> 'K) (render: 'K -> View<'T> -> #Doc) (view: View<seq<'T>>) : Doc =
+    let ConvertSeq f v = BindSeqCachedView f v
+
+    [<Inline>]
+    let BindSeqCachedViewBy (key: 'T -> 'K) (render: 'K -> View<'T> -> #Doc) (view: View<seq<'T>>) : Doc =
         As (Doc'.ConvertSeqBy key render view)
+
+    [<Inline>]
+    let ConvertSeqBy k f v = BindSeqCachedViewBy k f v
 
   // Form helpers ---------------------------------------------------------------
 
@@ -1486,13 +1498,13 @@ type DocExtensions() =
     static member Doc(v, f) = Doc.BindView f v
 
     [<Extension; Inline>]
-    static member Doc(v, f) = Doc.Convert f v
+    static member DocSeqCached(v, f) = Doc.BindSeqCached f v
 
     [<Extension; Inline>]
-    static member Doc(v, k, f) = Doc.ConvertBy k f v
+    static member DocSeqCached(v, k, f) = Doc.BindSeqCachedBy k f v
 
     [<Extension; Inline>]
-    static member Doc(v, f) = Doc.ConvertSeq f v
+    static member DocSeqCached(v, f) = Doc.BindSeqCachedView f v
 
     [<Extension; Inline>]
-    static member Doc(v, k, f) = Doc.ConvertSeqBy k f v
+    static member DocSeqCached(v, k, f) = Doc.BindSeqCachedViewBy k f v

--- a/WebSharper.UI.Next/Doc.Client.fs
+++ b/WebSharper.UI.Next/Doc.Client.fs
@@ -1,5 +1,6 @@
 namespace WebSharper.UI.Next.Client
 
+open System.Runtime.CompilerServices
 open WebSharper
 open WebSharper.JavaScript
 open WebSharper.UI.Next
@@ -1477,3 +1478,21 @@ module Doc =
     [<Inline>]
     let Radio attrs value var =
         Doc'.Radio attrs value var
+
+[<Extension; JavaScript>]
+type DocExtensions() =
+
+    [<Extension; Inline>]
+    static member Doc(v, f) = Doc.BindView f v
+
+    [<Extension; Inline>]
+    static member Doc(v, f) = Doc.Convert f v
+
+    [<Extension; Inline>]
+    static member Doc(v, k, f) = Doc.ConvertBy k f v
+
+    [<Extension; Inline>]
+    static member Doc(v, f) = Doc.ConvertSeq f v
+
+    [<Extension; Inline>]
+    static member Doc(v, k, f) = Doc.ConvertSeqBy k f v

--- a/WebSharper.UI.Next/Doc.Client.fsi
+++ b/WebSharper.UI.Next/Doc.Client.fsi
@@ -20,6 +20,7 @@
 
 namespace WebSharper.UI.Next.Client
 
+open System
 open System.Runtime.CompilerServices
 open WebSharper.JavaScript
 open WebSharper.UI.Next
@@ -407,19 +408,35 @@ module Doc =
 
     /// Converts a collection to Doc using View.Convert and embeds the concatenated result.
     /// Shorthand for View.Convert f |> View.Map Doc.Concat |> Doc.EmbedView.
+    val BindSeqCached : ('T -> #Doc) -> View<seq<'T>> -> Doc
+        when 'T : equality
+
+    [<Obsolete "Use Doc.BindSeqCached or view.DocSeqCached() instead.">]
     val Convert : ('T -> #Doc) -> View<seq<'T>> -> Doc
         when 'T : equality
 
     /// Doc.Convert with a custom key.
+    val BindSeqCachedBy : ('T -> 'K) -> ('T -> #Doc) -> View<seq<'T>> -> Doc
+        when 'K : equality
+
+    [<Obsolete "Use BindSeqCachedBy or view.DocSeqCached() instead.">]
     val ConvertBy : ('T -> 'K) -> ('T -> #Doc) -> View<seq<'T>> -> Doc
         when 'K : equality
 
     /// Converts a collection to Doc using View.ConvertSeq and embeds the concatenated result.
     /// Shorthand for View.ConvertSeq f |> View.Map Doc.Concat |> Doc.EmbedView.
+    val BindSeqCachedView : (View<'T> -> #Doc) -> View<seq<'T>> -> Doc
+        when 'T : equality
+
+    [<Obsolete "Use BindSeqCachedView or view.DocSeqCached() instead.">]
     val ConvertSeq : (View<'T> -> #Doc) -> View<seq<'T>> -> Doc
         when 'T : equality
 
     /// Doc.ConvertSeq with a custom key.
+    val BindSeqCachedViewBy : ('T -> 'K) -> ('K -> View<'T> -> #Doc) -> View<seq<'T>> -> Doc
+        when 'K : equality
+
+    [<Obsolete "Use BindSeqCachedViewBy or view.DocSeqCached() instead.">]
     val ConvertSeqBy : ('T -> 'K) -> ('K -> View<'T> -> #Doc) -> View<seq<'T>> -> Doc
         when 'K : equality
 
@@ -540,21 +557,21 @@ type DocExtensions =
     /// Converts a collection to Doc using View.Convert and embeds the concatenated result.
     /// Shorthand for View.Convert f |> View.Map Doc.Concat |> Doc.EmbedView.
     [<Extension>]
-    static member Doc : View<seq<'T>> * ('T -> #Doc) -> Doc
+    static member DocSeqCached : View<seq<'T>> * ('T -> #Doc) -> Doc
         when 'T : equality
 
     /// DocConvert with a custom key.
     [<Extension>]
-    static member Doc : View<seq<'T>> * ('T -> 'K) * ('T -> #Doc) -> Doc
+    static member DocSeqCached : View<seq<'T>> * ('T -> 'K) * ('T -> #Doc) -> Doc
         when 'K : equality
 
     /// Converts a collection to Doc using View.ConvertSeq and embeds the concatenated result.
     /// Shorthand for View.ConvertSeq f |> View.Map Doc.Concat |> Doc.EmbedView.
     [<Extension>]
-    static member Doc : View<seq<'T>> * (View<'T> -> #Doc) -> Doc
+    static member DocSeqCached : View<seq<'T>> * (View<'T> -> #Doc) -> Doc
         when 'T : equality
 
     /// DocConvertSeq with a custom key.
     [<Extension>]
-    static member Doc : View<seq<'T>> * ('T -> 'K) * ('K -> View<'T> -> #Doc) -> Doc
+    static member DocSeqCached : View<seq<'T>> * ('T -> 'K) * ('K -> View<'T> -> #Doc) -> Doc
         when 'K : equality

--- a/WebSharper.UI.Next/Doc.Client.fsi
+++ b/WebSharper.UI.Next/Doc.Client.fsi
@@ -20,6 +20,7 @@
 
 namespace WebSharper.UI.Next.Client
 
+open System.Runtime.CompilerServices
 open WebSharper.JavaScript
 open WebSharper.UI.Next
 
@@ -528,3 +529,32 @@ module Doc =
     val Radio : seq<Attr> -> 'T -> IRef<'T> -> Elt
         when 'T : equality
 
+[<Extension; Class>]
+type DocExtensions =
+
+    /// Embeds time-varying fragments.
+    /// Equivalent to View.Map followed by Doc.EmbedView.
+    [<Extension>]
+    static member Doc : View<'T> * ('T -> #Doc) -> Doc
+
+    /// Converts a collection to Doc using View.Convert and embeds the concatenated result.
+    /// Shorthand for View.Convert f |> View.Map Doc.Concat |> Doc.EmbedView.
+    [<Extension>]
+    static member Doc : View<seq<'T>> * ('T -> #Doc) -> Doc
+        when 'T : equality
+
+    /// DocConvert with a custom key.
+    [<Extension>]
+    static member Doc : View<seq<'T>> * ('T -> 'K) * ('T -> #Doc) -> Doc
+        when 'K : equality
+
+    /// Converts a collection to Doc using View.ConvertSeq and embeds the concatenated result.
+    /// Shorthand for View.ConvertSeq f |> View.Map Doc.Concat |> Doc.EmbedView.
+    [<Extension>]
+    static member Doc : View<seq<'T>> * (View<'T> -> #Doc) -> Doc
+        when 'T : equality
+
+    /// DocConvertSeq with a custom key.
+    [<Extension>]
+    static member Doc : View<seq<'T>> * ('T -> 'K) * ('K -> View<'T> -> #Doc) -> Doc
+        when 'K : equality

--- a/WebSharper.UI.Next/Reactive.fs
+++ b/WebSharper.UI.Next/Reactive.fs
@@ -178,7 +178,7 @@ type View =
 
      // Collections --------------------------------------------------------------
 
-    static member ConvertBy<'A,'B,'K when 'K : equality>
+    static member MapSeqCachedBy<'A,'B,'K when 'K : equality>
             (key: 'A -> 'K) (conv: 'A -> 'B) (view: View<seq<'A>>) =
         // Save history only for t - 1, discard older history.
         let state = ref (Dictionary())
@@ -200,8 +200,8 @@ type View =
             state := newState
             result)
 
-    static member Convert conv view =
-        View.ConvertBy (fun x -> x) conv view
+    static member MapSeqCached conv view =
+        View.MapSeqCachedBy (fun x -> x) conv view
 
     static member ConvertSeqNode conv value =
         let var = Var.Create value
@@ -212,7 +212,7 @@ type View =
             NView = view
         }
 
-    static member ConvertSeqBy<'A,'B,'K when 'K : equality>
+    static member MapSeqCachedViewBy<'A,'B,'K when 'K : equality>
             (key: 'A -> 'K) (conv: 'K -> View<'A> -> 'B) (view: View<seq<'A>>) =
         // Save history only for t - 1, discard older history.
         let state = ref (Dictionary())
@@ -237,8 +237,24 @@ type View =
             state := newState
             result)
 
-    static member ConvertSeq conv view =
-        View.ConvertSeqBy (fun x -> x) (fun _ v -> conv v) view
+    static member MapSeqCachedView conv view =
+        View.MapSeqCachedViewBy (fun x -> x) (fun _ v -> conv v) view
+
+    [<Inline>]
+    static member Convert<'A, 'B when 'A : equality> (f: 'A -> 'B) v =
+        View.MapSeqCached f v
+
+    [<Inline>]
+    static member ConvertBy<'A, 'B, 'K when 'K : equality> (k: 'A -> 'K) (f: 'A -> 'B) v =
+        View.MapSeqCachedBy k f v
+
+    [<Inline>]
+    static member ConvertSeq<'A, 'B when 'A : equality> (f: View<'A> -> 'B) v =
+        View.MapSeqCachedView f v
+
+    [<Inline>]
+    static member ConvertSeqBy<'A, 'B, 'K when 'K : equality> (k: 'A -> 'K) (f: 'K -> View<'A> -> 'B) v =
+        View.MapSeqCachedViewBy k f v
 
   // More cominators ------------------------------------------------------------
 
@@ -331,20 +347,20 @@ type ReactiveExtensions() =
     static member MapCached (v, f) = View.MapCached f v
 
     [<Extension; Inline>]
-    static member Convert<'A, 'B when 'A : equality>
-        (v: View<seq<'A>>, f: 'A -> 'B) = View.Convert f v
+    static member MapSeqCached<'A, 'B when 'A : equality>
+        (v: View<seq<'A>>, f: 'A -> 'B) = View.MapSeqCached f v
 
     [<Extension; Inline>]
-    static member ConvertBy<'A, 'B, 'K when 'K : equality>
-        (v: View<seq<'A>>, k: 'A -> 'K, f: 'A -> 'B) = View.ConvertBy k f v
+    static member MapSeqCached<'A, 'B, 'K when 'K : equality>
+        (v: View<seq<'A>>, k: 'A -> 'K, f: 'A -> 'B) = View.MapSeqCachedBy k f v
 
     [<Extension; Inline>]
-    static member ConvertSeq<'A, 'B when 'A : equality>
-        (v: View<seq<'A>>, f: View<'A> -> 'B) = View.ConvertSeq f v
+    static member MapSeqCached<'A, 'B when 'A : equality>
+        (v: View<seq<'A>>, f: View<'A> -> 'B) = View.MapSeqCachedView f v
 
     [<Extension; Inline>]
-    static member ConvertSeqBy<'A, 'B, 'K when 'K : equality>
-        (v: View<seq<'A>>, k: 'A -> 'K, f: 'K -> View<'A> -> 'B) = View.ConvertSeqBy k f v
+    static member MapSeqCached<'A, 'B, 'K when 'K : equality>
+        (v: View<seq<'A>>, k: 'A -> 'K, f: 'K -> View<'A> -> 'B) = View.MapSeqCachedViewBy k f v
 
 [<AutoOpen>]
 module IRefExtension =

--- a/WebSharper.UI.Next/Reactive.fsi
+++ b/WebSharper.UI.Next/Reactive.fsi
@@ -25,76 +25,112 @@
 /// please provide only pure (non-throwing) functions to this API.
 namespace WebSharper.UI.Next
 
+open System.Runtime.CompilerServices
+
+/// A read-only view on a time-varying value that a can be observed.
+[<Sealed>]
+type View<'A> =
+
+    /// Lifting functions.
+    member Map : ('A -> 'B) -> View<'B>
+
+    /// Lifting async functions.
+    member MapAsync : ('A -> Async<'B>) -> View<'B>
+
+    /// Dynamic composition.
+    member Bind : ('A -> View<'B>) -> View<'B>
+
+    /// Snapshots the second view whenever the first updates
+    member SnapshotOn : 'A -> View<'B> -> View<'A>
+
+    /// Only keeps the latest value of the second view when the predicate is true
+    member UpdateWhile : 'A -> View<bool> -> View<'A>
+
 /// An abstract time-varying variable than can be observed for changes
 /// by independent processes.
-type IRef<'T> =
+[<Interface>]
+type IRef<'A> =
 
     /// Gets the current value.
-    abstract Get : unit -> 'T
+    abstract Get : unit -> 'A
 
     /// Sets the current value.
-    abstract Set : 'T -> unit
+    abstract Set : 'A -> unit
 
     /// Updates the current value.
-    abstract Update : ('T -> 'T) -> unit
+    abstract Update : ('A -> 'A) -> unit
 
     /// Maybe updates the current value.
-    abstract UpdateMaybe : ('T -> 'T option) -> unit
+    abstract UpdateMaybe : ('A -> 'A option) -> unit
 
     /// Gets a view that observes changes on this variable.
-    abstract View : View<'T>
+    abstract View : View<'A>
 
     /// Gets the unique ID associated with the variable.
     abstract Id : string
 
 /// A time-varying variable that behaves like a ref cell that
 /// can also be observed for changes by independent processes.
-and [<Sealed>] Var<'T> =
-    interface IRef<'T>
+[<Sealed>]
+type Var<'A> =
+    interface IRef<'A>
 
-/// A read-only view on a time-varying value that a can be observed.
-and View<'T>
+    /// The corresponding view.
+    member View : View<'A>
+
+    /// Gets or sets the current value.
+    member Value : 'A with get, set
 
 /// Static operations on variables.
 [<Sealed>]
 type Var =
 
     /// Creates a fresh variable with the given initial value.
-    static member Create : 'T -> Var<'T>
+    static member Create : 'A -> Var<'A>
 
     /// Obtains the current value.
-    static member Get : Var<'T> -> 'T
+    static member Get : Var<'A> -> 'A
 
     /// Sets the current value.
-    static member Set : Var<'T> -> 'T -> unit
+    static member Set : Var<'A> -> 'A -> unit
 
     /// Sets the final value (after this, Set/Update are invalid).
     /// This is rarely needed, but can help solve memory leaks when
     /// mutliple views are scheduled to wait on a variable that is never
     /// going to change again.
-    static member SetFinal : Var<'T> -> 'T -> unit
+    static member SetFinal : Var<'A> -> 'A -> unit
 
     /// Updates the current value.
-    static member Update : Var<'T> -> ('T -> 'T) -> unit
+    static member Update : Var<'A> -> ('A -> 'A) -> unit
 
     /// Gets the unique ID associated with the var.
-    static member GetId  : Var<'T> -> int
+    static member GetId  : Var<'A> -> int
 
     /// Gets a reference to part of a var's value.
-    static member Lens : IRef<'T> -> get: ('T -> 'V) -> update: ('T -> 'V -> 'T) -> IRef<'V>
+    static member Lens : IRef<'A> -> get: ('A -> 'V) -> update: ('A -> 'V -> 'A) -> IRef<'V>
+
+/// Computation expression builder for views.
+[<Sealed>]
+type ViewBuilder =
+
+    /// Same as View.Bind.
+    member Bind : View<'A> * ('A -> View<'B>) -> View<'B>
+
+    /// Same as View.Const.
+    member Return : 'A -> View<'A>
 
 /// Static operations on views.
 [<Sealed>]
 type View =
 
     /// Creates a view that does not vary.
-    static member Const : 'T -> View<'T>
+    static member Const : 'A -> View<'A>
 
     /// Creation from a Var.
-    static member FromVar : Var<'T> -> View<'T>
+    static member FromVar : Var<'A> -> View<'A>
 
     /// Calls the given sink function repeatedly with the latest view value.
-    static member Sink : ('T -> unit) -> View<'T> -> unit
+    static member Sink : ('A -> unit) -> View<'A> -> unit
 
     /// Lifting functions.
     static member Map : ('A -> 'B) -> View<'A> -> View<'B>
@@ -113,7 +149,7 @@ type View =
     static member Apply : View<'A -> 'B> -> View<'A> -> View<'B>
 
     /// Dynamic composition.
-    static member Join : View<View<'T>> -> View<'T>
+    static member Join : View<View<'A>> -> View<'A>
 
     /// Dynamic composition.
     static member Bind : ('A -> View<'B>) -> View<'A> -> View<'B>
@@ -130,78 +166,79 @@ type View =
     /// The process remembers inputs from the previous step, and re-uses outputs
     /// from the previous step when possible instead of calling the converter function.
     /// Memory use is proportional to the longest sequence taken by the View.
-    static member Convert<'A,'B when 'A : equality> :
+    static member Convert<'A, 'B when 'A : equality> :
         ('A -> 'B) -> View<seq<'A>> -> View<seq<'B>>
 
     /// A variant of Convert with custom equality.
-    static member ConvertBy<'A,'B,'K when 'K : equality> :
+    static member ConvertBy<'A, 'B, 'K when 'K : equality> :
         ('A -> 'K) -> ('A -> 'B) -> View<seq<'A>> -> View<seq<'B>>
 
     /// An extended form of Convert where the conversion function accepts a
     /// reactive view.  At every step, changes to inputs identified as being
     /// the same object using equality are propagated via that view.
-    static member ConvertSeq<'A,'B when 'A : equality> :
+    static member ConvertSeq<'A, 'B when 'A : equality> :
         (View<'A> -> 'B) -> View<seq<'A>> -> View<seq<'B>>
 
     /// A variant of ConvertSeq with custom equality.
-    static member ConvertSeqBy<'A,'B,'K when 'K : equality> :
+    static member ConvertSeqBy<'A, 'B, 'K when 'K : equality> :
         ('A -> 'K) -> ('K -> View<'A> -> 'B) -> View<seq<'A>> -> View<seq<'B>>
-
-/// Computation expression builder for views.
-[<Sealed>]
-type ViewBuilder =
-
-    /// Same as View.Bind.
-    member Bind : View<'A> * ('A -> View<'B>) -> View<'B>
-
-    /// Same as View.Const.
-    member Return : 'T -> View<'T>
-
-/// Additions to View combinators.
-type View with
 
     /// An instance of ViewBuilder.
     static member Do : ViewBuilder
 
-/// More members on Var.
-type Var<'T> with
+/// More members on View.
+[<Extension; Class>]
+type ReactiveExtensions =
 
-    /// The corresponding view.
-    member View : View<'T>
+    /// Lift a function, doesn't call it again if the input static memberue is equal to the previous one.
+    [<Extension>]
+    static member MapCached : View<'A> * ('A -> 'B) -> View<'B>
+        when 'A : equality
 
-    /// Gets or sets the current value.
-    member Value : 'T with get, set
+    /// Starts a process doing stateful conversion with shallow memoization.
+    /// The process remembers inputs from the previous step, and re-uses outputs
+    /// from the previous step when possible instead of calling the converter function.
+    /// Memory use is proportional to the longest sequence taken by the View.
+    [<Extension>]
+    static member Convert<'A,'B when 'A : equality> :
+        View<seq<'A>> * ('A -> 'B) -> View<seq<'B>>
+
+    /// A variant of Convert with custom equality.
+    [<Extension>]
+    static member ConvertBy<'A,'B,'K when 'K : equality> :
+        View<seq<'A>> * ('A -> 'K) * ('A -> 'B) -> View<seq<'B>>
+
+    /// An extended form of Convert where the conversion function accepts a
+    /// reactive view.  At every step, changes to inputs identified as being
+    /// the same object using equality are propagated via that view.
+    [<Extension>]
+    static member ConvertSeq<'A,'B when 'A : equality> :
+        View<seq<'A>> * (View<'A> -> 'B) -> View<seq<'B>>
+
+    /// A variant of ConvertSeq with custom equality.
+    [<Extension>]
+    static member ConvertSeqBy<'A,'B,'K when 'K : equality> :
+        View<seq<'A>> * ('A -> 'K) * ('K -> View<'A> -> 'B) -> View<seq<'B>>
 
 [<AutoOpen>]
 module IRefExtension =
 
     type IRef<'T> with
-
-        /// Gets a reference to part of a var's value.
         member Lens : get: ('T -> 'V) -> update: ('T -> 'V -> 'T) -> IRef<'V>
-
-/// More members on View.
-type View<'T> with
-
-    /// Lifting functions.
-    member Map : ('T -> 'B) -> View<'B>
-
-    /// Dynamic composition.
-    member Bind : ('T -> View<'B>) -> View<'B>
 
 /// A special type of View whose value is only updated when Trigger is called.
 [<Sealed>]
-type Submitter<'T> =
+type Submitter<'A> =
 
     /// Get the output view of the submitter.
-    member View : View<'T>
+    member View : View<'A>
 
     /// Trigger the submitter, ie. cause its output view
     /// to get the same value as its input view.
     member Trigger : unit -> unit
 
     /// Get the input view of the submitter.
-    member Input : View<'T>
+    member Input : View<'A>
 
 [<Sealed>]
 type Submitter =
@@ -209,14 +246,15 @@ type Submitter =
     /// Create a Submitter from the given input view.
     /// Initially, the output view has the value init,
     /// until the Submitter is triggered for the first time.
-    static member Create : input: View<'T> -> init: 'T -> Submitter<'T>
+    static member Create : input: View<'A> -> init: 'A -> Submitter<'A>
 
     /// Get the output view of a submitter.
-    static member View : Submitter<'T> -> View<'T>
+    static member View : Submitter<'A> -> View<'A>
 
     /// Trigger a submitter, ie. cause its output view
     /// to get the same value as its input view.
-    static member Trigger : Submitter<'T> -> unit
+    static member Trigger : Submitter<'A> -> unit
 
     /// Get the input view of a submitter.
-    static member Input : Submitter<'T> -> View<'T>
+    static member Input : Submitter<'A> -> View<'A>
+

--- a/WebSharper.UI.Next/Reactive.fsi
+++ b/WebSharper.UI.Next/Reactive.fsi
@@ -25,6 +25,7 @@
 /// please provide only pure (non-throwing) functions to this API.
 namespace WebSharper.UI.Next
 
+open System
 open System.Runtime.CompilerServices
 
 /// A read-only view on a time-varying value that a can be observed.
@@ -164,22 +165,45 @@ type View =
 
     /// Starts a process doing stateful conversion with shallow memoization.
     /// The process remembers inputs from the previous step, and re-uses outputs
-    /// from the previous step when possible instead of calling the converter function.
+    /// from the previous step when possible instead of calling the mapping function.
     /// Memory use is proportional to the longest sequence taken by the View.
+    static member MapSeqCached<'A, 'B when 'A : equality> :
+        ('A -> 'B) -> View<seq<'A>> -> View<seq<'B>>
+
+    [<Obsolete "Use View.MapSeqCached or view.MapSeqCached() instead.">]
     static member Convert<'A, 'B when 'A : equality> :
         ('A -> 'B) -> View<seq<'A>> -> View<seq<'B>>
 
-    /// A variant of Convert with custom equality.
+    /// Starts a process doing stateful conversion with shallow memoization.
+    /// The process remembers inputs from the previous step, and re-uses outputs
+    /// from the previous step when possible instead of calling the mapping function.
+    /// Memory use is proportional to the longest sequence taken by the View.
+    /// Inputs are compared via their `key`.
+    static member MapSeqCachedBy<'A, 'B, 'K when 'K : equality> :
+        ('A -> 'K) -> ('A -> 'B) -> View<seq<'A>> -> View<seq<'B>>
+
+    [<Obsolete "Use View.MapSeqCachedBy or view.MapSeqCached() instead.">]
     static member ConvertBy<'A, 'B, 'K when 'K : equality> :
         ('A -> 'K) -> ('A -> 'B) -> View<seq<'A>> -> View<seq<'B>>
 
-    /// An extended form of Convert where the conversion function accepts a
+    /// An extended form of MapSeqCached where the conversion function accepts a
     /// reactive view.  At every step, changes to inputs identified as being
     /// the same object using equality are propagated via that view.
+    static member MapSeqCachedView<'A, 'B when 'A : equality> :
+        (View<'A> -> 'B) -> View<seq<'A>> -> View<seq<'B>>
+
+    [<Obsolete "Use View.MapSeqCachedView or view.MapSeqCached() instead.">]
     static member ConvertSeq<'A, 'B when 'A : equality> :
         (View<'A> -> 'B) -> View<seq<'A>> -> View<seq<'B>>
 
-    /// A variant of ConvertSeq with custom equality.
+    /// An extended form of MapSeqCached where the conversion function accepts a
+    /// reactive view.  At every step, changes to inputs identified as being
+    /// the same object using equality are propagated via that view.
+    /// Inputs are compared via their `key`.
+    static member MapSeqCachedViewBy<'A, 'B, 'K when 'K : equality> :
+        ('A -> 'K) -> ('K -> View<'A> -> 'B) -> View<seq<'A>> -> View<seq<'B>>
+
+    [<Obsolete "Use View.MapSeqCachedViewBy or view.MapSeqCached() instead.">]
     static member ConvertSeqBy<'A, 'B, 'K when 'K : equality> :
         ('A -> 'K) -> ('K -> View<'A> -> 'B) -> View<seq<'A>> -> View<seq<'B>>
 
@@ -197,28 +221,35 @@ type ReactiveExtensions =
 
     /// Starts a process doing stateful conversion with shallow memoization.
     /// The process remembers inputs from the previous step, and re-uses outputs
-    /// from the previous step when possible instead of calling the converter function.
+    /// from the previous step when possible instead of calling the mapping function.
     /// Memory use is proportional to the longest sequence taken by the View.
     [<Extension>]
-    static member Convert<'A,'B when 'A : equality> :
-        View<seq<'A>> * ('A -> 'B) -> View<seq<'B>>
+    static member MapSeqCached<'A,'B when 'A : equality> :
+        View<seq<'A>> * f: ('A -> 'B) -> View<seq<'B>>
 
-    /// A variant of Convert with custom equality.
+    /// Starts a process doing stateful conversion with shallow memoization.
+    /// The process remembers inputs from the previous step, and re-uses outputs
+    /// from the previous step when possible instead of calling the mapping function.
+    /// Memory use is proportional to the longest sequence taken by the View.
+    /// Inputs are compared via their `key`.
     [<Extension>]
-    static member ConvertBy<'A,'B,'K when 'K : equality> :
-        View<seq<'A>> * ('A -> 'K) * ('A -> 'B) -> View<seq<'B>>
+    static member MapSeqCached<'A,'B,'K when 'K : equality> :
+        View<seq<'A>> * key: ('A -> 'K) * f: ('A -> 'B) -> View<seq<'B>>
 
-    /// An extended form of Convert where the conversion function accepts a
+    /// An extended form of MapSeqCached where the conversion function accepts a
     /// reactive view.  At every step, changes to inputs identified as being
     /// the same object using equality are propagated via that view.
     [<Extension>]
-    static member ConvertSeq<'A,'B when 'A : equality> :
-        View<seq<'A>> * (View<'A> -> 'B) -> View<seq<'B>>
+    static member MapSeqCached<'A,'B when 'A : equality> :
+        View<seq<'A>> * f: (View<'A> -> 'B) -> View<seq<'B>>
 
-    /// A variant of ConvertSeq with custom equality.
+    /// An extended form of MapSeqCached where the conversion function accepts a
+    /// reactive view.  At every step, changes to inputs identified as being
+    /// the same object using equality are propagated via that view.
+    /// Inputs are compared via their `key`.
     [<Extension>]
-    static member ConvertSeqBy<'A,'B,'K when 'K : equality> :
-        View<seq<'A>> * ('A -> 'K) * ('K -> View<'A> -> 'B) -> View<seq<'B>>
+    static member MapSeqCached<'A,'B,'K when 'K : equality> :
+        View<seq<'A>> * key: ('A -> 'K) * f: ('K -> View<'A> -> 'B) -> View<seq<'B>>
 
 [<AutoOpen>]
 module IRefExtension =

--- a/WebSharper.UI.Next/WebSharper.UI.Next.fsproj
+++ b/WebSharper.UI.Next/WebSharper.UI.Next.fsproj
@@ -1,20 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <ProjectGuid>085a6f78-50a7-46cf-b040-9853ec580be5</ProjectGuid>
+    <SchemaVersion>2.0</SchemaVersion>
     <Name>WebSharper.UI.Next</Name>
+    <RootNamespace>$(Name)</RootNamespace>
+    <AssemblyName>$(Name)</AssemblyName>
     <WebSharperProject>Library</WebSharperProject>
     <OutputType>Library</OutputType>
     <OutputPath>../build/net40</OutputPath>
+    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OtherFlags>
-    </OtherFlags>
   </PropertyGroup>
-  <Import Project="../build/net40/$(Name).proj" />
-  <Import Project="../msbuild/FSharp.targets" />
   <ItemGroup>
     <Compile Include="Utility\Abbrev.fs" />
     <Compile Include="Utility\AppendList.fsi" />
@@ -52,4 +54,19 @@
     <Compile Include="Input.fs" />
     <EmbeddedResource Include="h5f.js" />
   </ItemGroup>
+  <!-- F# targets -->
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <Import Project="../build/net40/$(Name).proj" />
 </Project>

--- a/build.fsx
+++ b/build.fsx
@@ -5,6 +5,7 @@ let bt =
     BuildTool().PackageId("WebSharper.UI.Next")
         .VersionFrom("WebSharper")
         .WithFramework(fun fw -> fw.Net40)
+        .WithFSharpVersion(FSharpVersion.FSharp30)
 
 let main =
     bt.WebSharper.Library("WebSharper.UI.Next")
@@ -22,7 +23,8 @@ let tmpl =
             ])
 
 let test = 
-    bt.WebSharper.BundleWebsite("WebSharper.UI.Next.Tests")        
+    bt.WithFSharpVersion(FSharpVersion.FSharp31)
+        .WebSharper.BundleWebsite("WebSharper.UI.Next.Tests")
         .SourcesFromProject()
         .References(fun r ->
             [


### PR DESCRIPTION
Those are overloaded extension methods, so I'm pushing this as a PR so we can discuss if it's a good idea to overload them rather than give them separate names similar to their static member counterparts.

Summary:

* `View.Convert`, `View.ConvertBy`, `View.ConvertSeq` and `View.ConvertSeqBy` are now also implemented as extension methods on `View<seq<_>>`, all overloaded with the same name `.Convert()`.
* `Doc.Convert`, `Doc.ConvertBy`, `Doc.ConvertSeq` and `Doc.ConvertSeqBy` are similarly implemented as extension methods on `View<seq<_>>` with the same name `.Doc()`.
* Additionally `Doc.BindView` is implemented as yet another overload of `.Doc()` on `View<_>`.
* Due to the way extension methods work, these need to take tupled arguments, unlike their existing static method counterparts.

```fsharp
myListModel.View |> Doc.ConvertSeqBy getItemKey (fun k v -> div [...])

// can now also be written as:

myListModel.View.Doc(getItemKey, fun k v -> div [...])
```