### PR TITLE
Cache ProvidedTypeDefinition in TemplateProvider

### DIFF
--- a/WebSharper.UI.Next.Templating/Main.fs
+++ b/WebSharper.UI.Next.Templating/Main.fs
@@ -26,13 +26,13 @@ open System.IO
 open System.Reflection
 open System.Xml.Linq
 open System.Text.RegularExpressions
-open Microsoft.FSharp.Reflection
 open Microsoft.FSharp.Quotations
 open Microsoft.FSharp.Core.CompilerServices
 open WebSharper.UI.Next
 open WebSharper.UI.Next.Client
 
 open ProviderImplementation.ProvidedTypes
+open System.Runtime.Caching
 
 [<AutoOpen>]
 module internal Utils =
@@ -79,6 +79,18 @@ module internal Utils =
                 | a -> a
             )
 
+[<AutoOpen>]
+module Cache =
+    type MemoryCache with 
+        member x.GetOrAdd(key, value: Lazy<_>, ?expiration) = 
+            let policy = CacheItemPolicy()
+            policy.SlidingExpiration <- defaultArg expiration <| TimeSpan.FromHours 24.
+            match x.AddOrGetExisting(key, value, policy) with
+            | :? Lazy<ProvidedTypeDefinition> as item -> item.Value 
+            | x -> 
+                assert(x = null)
+                value.Value
+
 [<TypeProvider>]
 type TemplateProvider(cfg: TypeProviderConfig) as this =
     inherit TypeProviderForNamespaces()
@@ -123,314 +135,318 @@ type TemplateProvider(cfg: TypeProviderConfig) as this =
             | a -> VarUnchecked a.Value
         | a -> Var a.Value
 
+    let cache = new MemoryCache("YamlConfigProvider")
+
     do
         this.Disposing.Add <| fun _ ->
             if watcher <> null then watcher.Dispose()
+            cache.Dispose()
 
         templateTy.DefineStaticParameters(
             [ProvidedStaticParameter("path", typeof<string>)],
             fun typename pars ->
-                match pars with
-                | [| :? string as path |] ->
-                    let ty = ProvidedTypeDefinition(thisAssembly, rootNamespace, typename, None)
-
-                    let htmlFile = 
-                        if Path.IsPathRooted path then path 
-                        else cfg.ResolutionFolder +/ path
-
-                    if cfg.IsInvalidationSupported then
-                        if watcher <> null then watcher.Dispose()
-                        watcher <-
-                            new FileSystemWatcher(Path.GetDirectoryName htmlFile, Path.GetFileName htmlFile, 
-                                NotifyFilter = (NotifyFilters.LastWrite ||| NotifyFilters.Security ||| NotifyFilters.FileName)
-                            )
-                        watcher.Changed.Add <| fun _ -> this.Invalidate()
-                        watcher.Deleted.Add <| fun _ -> this.Invalidate()
-                        watcher.Renamed.Add <| fun _ -> this.Invalidate()
-                        watcher.Created.Add <| fun _ -> this.Invalidate()
-                        watcher.EnableRaisingEvents <- true
-
-                    let xml =
-                        try // Try to load the file as a whole XML document, ie. single root node with optional DTD.
-                            let xmlDoc = XDocument.Load(htmlFile, LoadOptions.PreserveWhitespace)
-                            let xml = XElement(xn"wrapper")
-                            xml.Add(xmlDoc.Root)
-                            xml
-                        with :? System.Xml.XmlException ->
-                            // Try to load the file as a XML fragment, ie. potentially several root nodes.
-                            XDocument.Parse("<wrapper>" + File.ReadAllText htmlFile + "</wrapper>", LoadOptions.PreserveWhitespace).Root
-
-                    let isSingleElt =
-                        let firstNode = xml.FirstNode
-                        isNull firstNode.NextNode &&
-                        firstNode.NodeType = Xml.XmlNodeType.Element &&
-                        isNull ((firstNode :?> XElement).Attribute(dataReplace))
-
-                    let innerTemplates =
-                        xml.Descendants() |> Seq.choose (fun e -> 
-                            match e.Attribute(dataTemplate) with
-                            | null ->
-                                match e.Attribute(dataChildrenTemplate) with
-                                | null -> None
-                                | a -> Some (e, a, false)
-                            | a -> Some (e, a, true)
-                        )
-                        |> List.ofSeq
-                        |> List.map (fun (e, a, wrap) ->
-                            let name = a.Value
-                            a.Remove()
-                            let e =
-                                match e.AnyAttributeOf(dataReplace, dataHole) with
+                let value = lazy (
+                    match pars with
+                    | [| :? string as path |] ->
+                        let ty = ProvidedTypeDefinition(thisAssembly, rootNamespace, typename, None)
+                    
+                        let htmlFile = 
+                            if Path.IsPathRooted path then path 
+                            else cfg.ResolutionFolder +/ path
+                    
+                        if cfg.IsInvalidationSupported then
+                            if watcher <> null then watcher.Dispose()
+                            watcher <-
+                                new FileSystemWatcher(Path.GetDirectoryName htmlFile, Path.GetFileName htmlFile, 
+                                    NotifyFilter = (NotifyFilters.LastWrite ||| NotifyFilters.Security ||| NotifyFilters.FileName)
+                                )
+                            watcher.Changed.Add <| fun _ -> this.Invalidate()
+                            watcher.Deleted.Add <| fun _ -> this.Invalidate()
+                            watcher.Renamed.Add <| fun _ -> this.Invalidate()
+                            watcher.Created.Add <| fun _ -> this.Invalidate()
+                            watcher.EnableRaisingEvents <- true
+                    
+                        let xml =
+                            try // Try to load the file as a whole XML document, ie. single root node with optional DTD.
+                                let xmlDoc = XDocument.Load(htmlFile, LoadOptions.PreserveWhitespace)
+                                let xml = XElement(xn"wrapper")
+                                xml.Add(xmlDoc.Root)
+                                xml
+                            with :? System.Xml.XmlException ->
+                                // Try to load the file as a XML fragment, ie. potentially several root nodes.
+                                XDocument.Parse("<wrapper>" + File.ReadAllText htmlFile + "</wrapper>", LoadOptions.PreserveWhitespace).Root
+                    
+                        let isSingleElt =
+                            let firstNode = xml.FirstNode
+                            isNull firstNode.NextNode &&
+                            firstNode.NodeType = Xml.XmlNodeType.Element &&
+                            isNull ((firstNode :?> XElement).Attribute(dataReplace))
+                    
+                        let innerTemplates =
+                            xml.Descendants() |> Seq.choose (fun e -> 
+                                match e.Attribute(dataTemplate) with
                                 | null ->
-                                    e.Remove()
-                                    e
-                                | a ->
-                                    let e = XElement(e)
-                                    e.Attribute(a.Name).Remove()
-                                    e
-                            name, if wrap then XElement(xn"body", e) else e
-                        )
-                                        
-                    let addTemplateMethod (t: XElement) (toTy: ProvidedTypeDefinition) =
-                        let holes = Dictionary()
-
-                        let getSimpleHole name : Expr<'T> =
-                            match holes.TryGetValue(name) with
-                            | true, Hole.Simple t when t = typeof<'T> ->
-                                ()
-                            | true, _ ->
-                                failwithf "Invalid multiple use of variable name in the same template: %s" name
-                            | false, _ ->
-                                holes.Add(name, Hole.Simple typeof<'T>)
-                            Expr.Var (Var (name, typeof<'T>)) |> Expr.Cast
-
-                        let getVarHole name : Expr<IRef<'T>> =
-                            match holes.TryGetValue(name) with
-                            | true, Hole.IRef(valTy = valTy) ->
-                                if valTy = typeof<'T> then
-                                    ()
-                                else
-                                    failwithf "Invalid multiple use of variable name for differently typed Vars: %s" name
-                            | true, Hole.View valTy ->
-                                if valTy = typeof<'T> then
-                                    holes.Remove(name) |> ignore
-                                    holes.Add(name, Hole.IRef(valTy = typeof<'T>, hasView = true))
-                                else
-                                    failwithf "Invalid multiple use of variable name for differently typed View and Var: %s" name
-                            | true, Hole.Simple _
-                            | true, Hole.Event ->
-                                failwithf "Invalid multiple use of variable name in the same template: %s" name
-                            | false, _ ->
-                                holes.Add(name, Hole.IRef(valTy = typeof<'T>, hasView = false))
-                            Expr.Var (Var (name, typeof<IRef<'T>>)) |> Expr.Cast
-
-                        let getViewHole name : Expr<View<'T>> =
-                            match holes.TryGetValue(name) with
-                            | true, Hole.IRef(valTy = valTy; hasView = hasView) ->
-                                if valTy = typeof<'T> then
-                                    if not hasView then
-                                        holes.Remove(name) |> ignore
-                                        holes.Add(name, Hole.IRef(valTy = valTy, hasView = true))
-                                else
-                                    failwithf "Invalid multiple use of variable name for differently typed View and Var: %s" name
-                            | true, Hole.View valTy ->
-                                if valTy = typeof<'T> then
-                                    ()
-                                else
-                                    failwithf "Invalid multiple use of variable name for differently typed Views: %s" name
-                            | true, Hole.Simple _
-                            | true, Hole.Event ->
-                                failwithf "Invalid multiple use of variable name in the same template: %s" name
-                            | false, _ ->
-                                holes.Add(name, Hole.View typeof<'T>)
-                            Expr.Var (Var (name, typeof<View<'T>>)) |> Expr.Cast
-
-                        let getEventHole name : Expr<WebSharper.JavaScript.Dom.Element -> WebSharper.JavaScript.Dom.Event -> unit> =
-                            match holes.TryGetValue(name) with
-                            | true, Hole.Event -> ()
-                            | true, Hole.Simple _
-                            | true, Hole.IRef _
-                            | true, Hole.View _ ->
-                                failwithf "Invalid multiple use of variable name in the same template: %s" name
-                            | false, _ ->
-                                holes.Add(name, Hole.Event)
-                            Expr.Var (Var (name, EventTy)) |> Expr.Cast
-
-                        let getParts (t: string) =
-                            if t = "" then [] else
-                            let holes =
-                                textHoleRegex.Matches t |> Seq.cast<Match>
-                                |> Seq.map (fun m ->
-                                    m.Groups.[1].Value <> "", m.Groups.[2].Value, m.Index)
-                                |> List.ofSeq
-                            if List.isEmpty holes then
-                                [ TextPart t ]
-                            else
-                                [
-                                    let l = ref 0
-                                    for isView, name, i in holes do
-                                        if i > !l then
-                                            let s = t.[!l .. i - 1]
-                                            yield TextPart s
-                                        yield (if isView then TextViewHole else TextHole) name
-                                        l := i + name.Length + if isView then 4 else 3
-                                    if t.Length > !l then
-                                        let s = t.[!l ..]
-                                        yield TextPart s
-                                ]   
-
-                        let rec createNode isRoot (e: XElement) =
-                            match e.Attribute(dataReplace) with
-                            | null ->
-                                let attrs =
-                                    if isRoot then <@ [||] @> else
-                                    e.Attributes() 
-                                    |> Seq.filter (fun a ->
-                                        if a.Name = dataHole then
-                                            (|SpecialHole|_|) a = Some ()
-                                        else
-                                            a.Name <> dataVar && a.Name <> dataVarUnchecked)
-                                    |> Seq.map (fun a -> 
-                                        let n = a.Name.LocalName
-                                        if n.StartsWith dataEvent then
-                                            let eventName = n.[dataEvent.Length..]
-                                            <@ Attr.Handler eventName %(getEventHole a.Value) @>
-                                        elif a.Name = dataAttr then
-                                            getSimpleHole a.Value
-                                        else
-                                            let parts = getParts a.Value
-                                            let rec groupTextPartsAndTextHoles cur l =
-                                                let toStringRev l =
-                                                    match l with
-                                                    | [] -> <@ "" @>
-                                                    | [e] -> e
-                                                    | [e2; e1] -> <@ %e1 + %e2 @>
-                                                    | es -> <@ System.String.Concat %(ExprArray (List.rev es)) @>
-                                                    |> Choice1Of2
-                                                match l with
-                                                | [] -> [toStringRev cur]
-                                                | TextPart t :: rest -> groupTextPartsAndTextHoles (<@ t @> :: cur) rest
-                                                | TextHole h :: rest -> groupTextPartsAndTextHoles (getSimpleHole h :: cur) rest
-                                                | TextViewHole h :: rest -> toStringRev cur :: Choice2Of2 (getViewHole h : Expr<View<string>>) :: groupTextPartsAndTextHoles [] rest
-                                            match groupTextPartsAndTextHoles [] parts with
-                                            | [] -> <@ Attr.Create n "" @>
-                                            | [Choice1Of2 s] -> <@ Attr.Create n %s @>
-                                            | parts ->
-                                                let rec collect parts =
-                                                    match parts with
-                                                    | [ Choice2Of2 h ] -> h
-                                                    | [ Choice2Of2 h; Choice1Of2 t ] -> 
-                                                        <@ View.Map (fun s -> s + %t) %h @>
-                                                    | [ Choice1Of2 t; Choice2Of2 h ] -> 
-                                                        <@ View.Map (fun s -> %t + s) %h @>
-                                                    | [ Choice1Of2 t1; Choice2Of2 h; Choice1Of2 t2 ] ->
-                                                        <@ View.Map (fun s -> %t1 + s + %t2) %h @>
-                                                    | Choice2Of2 h :: rest ->
-                                                        <@ View.Map2 (fun s1 s2 -> s1 + s2) %h %(collect rest) @>
-                                                    | Choice1Of2 t :: Choice2Of2 h :: rest ->
-                                                        <@ View.Map2 (fun s1 s2 -> %t + s1 + s2) %h %(collect rest) @>
-                                                    | _ -> failwithf "collecting attribute parts failure" // should not happen
-                                                <@ Attr.Dynamic n %(collect parts) @>
-                                    )
-                                    |> ExprArray
-                                
-                                let nodes = 
-                                    match e.Attribute(dataHole) with
+                                    match e.Attribute(dataChildrenTemplate) with
+                                    | null -> None
+                                    | a -> Some (e, a, false)
+                                | a -> Some (e, a, true)
+                            )
+                            |> List.ofSeq
+                            |> List.map (fun (e, a, wrap) ->
+                                let name = a.Value
+                                a.Remove()
+                                let e =
+                                    match e.AnyAttributeOf(dataReplace, dataHole) with
                                     | null ->
-                                        e.Nodes() |> Seq.collect (function
-                                            | :? XElement as n -> [ createNode false n ]
-                                            | :? XCData as n -> let v = n.Value in [ <@ Doc.Verbatim v @> ]
-                                            | :? XText as n ->
-                                                getParts n.Value
-                                                |> List.map (function
-                                                    | TextPart t -> <@ Doc.TextNode t @>
-                                                    | TextHole h -> <@ Doc.TextNode %(getSimpleHole h) @>
-                                                    | TextViewHole h -> <@ Doc.TextView %(getViewHole h) @>
-                                                )
-                                            | _ -> []
-                                        ) 
-                                        |> ExprArray
-                                    | SpecialHole -> <@ [||] @>
-                                    | a -> <@ Array.ofSeq %(getSimpleHole a.Value) @>
-
-                                if isRoot then 
-                                    <@ Doc.Concat %nodes @>
+                                        e.Remove()
+                                        e
+                                    | a ->
+                                        let e = XElement(e)
+                                        e.Attribute(a.Name).Remove()
+                                        e
+                                name, if wrap then XElement(xn"body", e) else e
+                            )
+                                            
+                        let addTemplateMethod (t: XElement) (toTy: ProvidedTypeDefinition) =
+                            let holes = Dictionary()
+                    
+                            let getSimpleHole name : Expr<'T> =
+                                match holes.TryGetValue(name) with
+                                | true, Hole.Simple t when t = typeof<'T> ->
+                                    ()
+                                | true, _ ->
+                                    failwithf "Invalid multiple use of variable name in the same template: %s" name
+                                | false, _ ->
+                                    holes.Add(name, Hole.Simple typeof<'T>)
+                                Expr.Var (Var (name, typeof<'T>)) |> Expr.Cast
+                    
+                            let getVarHole name : Expr<IRef<'T>> =
+                                match holes.TryGetValue(name) with
+                                | true, Hole.IRef(valTy = valTy) ->
+                                    if valTy = typeof<'T> then
+                                        ()
+                                    else
+                                        failwithf "Invalid multiple use of variable name for differently typed Vars: %s" name
+                                | true, Hole.View valTy ->
+                                    if valTy = typeof<'T> then
+                                        holes.Remove(name) |> ignore
+                                        holes.Add(name, Hole.IRef(valTy = typeof<'T>, hasView = true))
+                                    else
+                                        failwithf "Invalid multiple use of variable name for differently typed View and Var: %s" name
+                                | true, Hole.Simple _
+                                | true, Hole.Event ->
+                                    failwithf "Invalid multiple use of variable name in the same template: %s" name
+                                | false, _ ->
+                                    holes.Add(name, Hole.IRef(valTy = typeof<'T>, hasView = false))
+                                Expr.Var (Var (name, typeof<IRef<'T>>)) |> Expr.Cast
+                    
+                            let getViewHole name : Expr<View<'T>> =
+                                match holes.TryGetValue(name) with
+                                | true, Hole.IRef(valTy = valTy; hasView = hasView) ->
+                                    if valTy = typeof<'T> then
+                                        if not hasView then
+                                            holes.Remove(name) |> ignore
+                                            holes.Add(name, Hole.IRef(valTy = valTy, hasView = true))
+                                    else
+                                        failwithf "Invalid multiple use of variable name for differently typed View and Var: %s" name
+                                | true, Hole.View valTy ->
+                                    if valTy = typeof<'T> then
+                                        ()
+                                    else
+                                        failwithf "Invalid multiple use of variable name for differently typed Views: %s" name
+                                | true, Hole.Simple _
+                                | true, Hole.Event ->
+                                    failwithf "Invalid multiple use of variable name in the same template: %s" name
+                                | false, _ ->
+                                    holes.Add(name, Hole.View typeof<'T>)
+                                Expr.Var (Var (name, typeof<View<'T>>)) |> Expr.Cast
+                    
+                            let getEventHole name : Expr<WebSharper.JavaScript.Dom.Element -> WebSharper.JavaScript.Dom.Event -> unit> =
+                                match holes.TryGetValue(name) with
+                                | true, Hole.Event -> ()
+                                | true, Hole.Simple _
+                                | true, Hole.IRef _
+                                | true, Hole.View _ ->
+                                    failwithf "Invalid multiple use of variable name in the same template: %s" name
+                                | false, _ ->
+                                    holes.Add(name, Hole.Event)
+                                Expr.Var (Var (name, EventTy)) |> Expr.Cast
+                    
+                            let getParts (t: string) =
+                                if t = "" then [] else
+                                let holes =
+                                    textHoleRegex.Matches t |> Seq.cast<Match>
+                                    |> Seq.map (fun m ->
+                                        m.Groups.[1].Value <> "", m.Groups.[2].Value, m.Index)
+                                    |> List.ofSeq
+                                if List.isEmpty holes then
+                                    [ TextPart t ]
                                 else
-                                    let n = e.Name.LocalName
-                                    let var a unchecked =
-                                        if n.ToLower() = "input" then
-                                            match e.Attribute(xn"type") with
-                                            | null -> <@ Doc.Input %attrs %(getVarHole a) :> Doc @>
-                                            | t ->
-                                                match t.Value with
-                                                | "checkbox" -> <@ Doc.CheckBox %attrs %(getVarHole a) :> _ @>
-                                                | "number" ->
-                                                    if unchecked then
-                                                        <@ Doc.FloatInputUnchecked %attrs %(getVarHole a) :> _ @>
-                                                    else
-                                                        <@ Doc.FloatInput %attrs %(getVarHole a) :> _ @>
-                                                | "password" -> <@ Doc.PasswordBox %attrs %(getVarHole a) :> _ @>
-                                                | "text" | _ -> <@ Doc.Input %attrs %(getVarHole a) :> _ @>
-                                        elif n.ToLower() = "textarea" then
-                                            <@ Doc.InputArea %attrs %(getVarHole a) :> _ @>
-                                        elif n.ToLower() = "select" then
-                                            <@ Doc.Element "select"
-                                                (Seq.append
-                                                    (Seq.singleton (Attr.Value %(getVarHole a)))
-                                                    %attrs)
-                                                %nodes :> _ @>
-                                        else failwithf "data-var attribute \"%s\" on invalid element \"%s\"" a n
-                                    match e with
-                                    | NoVar -> <@ Doc.Element n %attrs %nodes :> _ @>
-                                    | Var a -> var a false
-                                    | VarUnchecked a -> var a true
-
-                            | SpecialHole as a ->
-                                let elName = e.Name.LocalName
-                                let attrValue = a.Value
-                                <@ Doc.Element elName [|Attr.Create "data-replace" attrValue |] [||] :> _ @>
-                            | a -> <@ Doc.Concat %(getSimpleHole a.Value : Expr<seq<Doc>>) @>
-                        
-                        let mainExpr = t |> createNode true
-
-                        let pars = [ for KeyValue(name, h) in holes -> ProvidedParameter(name, h.ArgType) ]
-
-                        let code (args: Expr list) =
-                            let varMap = Dictionary()
-                            for KeyValue(name, hole), arg in Seq.zip holes args do
-                                match hole with
-                                | Hole.Simple ty ->
-                                    varMap.Add((name, ty), arg)
-                                | Hole.Event ->
-                                    varMap.Add((name, EventTy), arg)
-                                | Hole.View valTy ->
-                                    varMap.Add((name, ViewOf valTy), arg)
-                                | Hole.IRef(valTy, hasView) ->
-                                    let irefTy = IRefOf valTy
-                                    varMap.Add((name, irefTy), arg)
-                                    if hasView then
-                                        varMap.Add((name, ViewOf valTy),
-                                            Expr.Call(arg,
-                                                irefTy.GetProperty("View").GetGetMethod(),
-                                                []))
-                            mainExpr.Substitute(fun v ->
-                                match varMap.TryGetValue((v.Name, v.Type)) with
-                                | true, e -> Some e
-                                | false, _ -> None)
-                        
-                        ProvidedMethod("Doc", pars, typeof<Doc>, IsStaticMethod = true, InvokeCode = code)
-                        |> toTy.AddMember
-                        if isSingleElt then
-                            ProvidedMethod("Elt", pars, typeof<Elt>, IsStaticMethod = true,
-                                InvokeCode = fun args -> <@@ (%%code args : Doc) :?> Elt @@>)
+                                    [
+                                        let l = ref 0
+                                        for isView, name, i in holes do
+                                            if i > !l then
+                                                let s = t.[!l .. i - 1]
+                                                yield TextPart s
+                                            yield (if isView then TextViewHole else TextHole) name
+                                            l := i + name.Length + if isView then 4 else 3
+                                        if t.Length > !l then
+                                            let s = t.[!l ..]
+                                            yield TextPart s
+                                    ]   
+                    
+                            let rec createNode isRoot (e: XElement) =
+                                match e.Attribute(dataReplace) with
+                                | null ->
+                                    let attrs =
+                                        if isRoot then <@ [||] @> else
+                                        e.Attributes() 
+                                        |> Seq.filter (fun a ->
+                                            if a.Name = dataHole then
+                                                (|SpecialHole|_|) a = Some ()
+                                            else
+                                                a.Name <> dataVar && a.Name <> dataVarUnchecked)
+                                        |> Seq.map (fun a -> 
+                                            let n = a.Name.LocalName
+                                            if n.StartsWith dataEvent then
+                                                let eventName = n.[dataEvent.Length..]
+                                                <@ Attr.Handler eventName %(getEventHole a.Value) @>
+                                            elif a.Name = dataAttr then
+                                                getSimpleHole a.Value
+                                            else
+                                                let parts = getParts a.Value
+                                                let rec groupTextPartsAndTextHoles cur l =
+                                                    let toStringRev l =
+                                                        match l with
+                                                        | [] -> <@ "" @>
+                                                        | [e] -> e
+                                                        | [e2; e1] -> <@ %e1 + %e2 @>
+                                                        | es -> <@ System.String.Concat %(ExprArray (List.rev es)) @>
+                                                        |> Choice1Of2
+                                                    match l with
+                                                    | [] -> [toStringRev cur]
+                                                    | TextPart t :: rest -> groupTextPartsAndTextHoles (<@ t @> :: cur) rest
+                                                    | TextHole h :: rest -> groupTextPartsAndTextHoles (getSimpleHole h :: cur) rest
+                                                    | TextViewHole h :: rest -> toStringRev cur :: Choice2Of2 (getViewHole h : Expr<View<string>>) :: groupTextPartsAndTextHoles [] rest
+                                                match groupTextPartsAndTextHoles [] parts with
+                                                | [] -> <@ Attr.Create n "" @>
+                                                | [Choice1Of2 s] -> <@ Attr.Create n %s @>
+                                                | parts ->
+                                                    let rec collect parts =
+                                                        match parts with
+                                                        | [ Choice2Of2 h ] -> h
+                                                        | [ Choice2Of2 h; Choice1Of2 t ] -> 
+                                                            <@ View.Map (fun s -> s + %t) %h @>
+                                                        | [ Choice1Of2 t; Choice2Of2 h ] -> 
+                                                            <@ View.Map (fun s -> %t + s) %h @>
+                                                        | [ Choice1Of2 t1; Choice2Of2 h; Choice1Of2 t2 ] ->
+                                                            <@ View.Map (fun s -> %t1 + s + %t2) %h @>
+                                                        | Choice2Of2 h :: rest ->
+                                                            <@ View.Map2 (fun s1 s2 -> s1 + s2) %h %(collect rest) @>
+                                                        | Choice1Of2 t :: Choice2Of2 h :: rest ->
+                                                            <@ View.Map2 (fun s1 s2 -> %t + s1 + s2) %h %(collect rest) @>
+                                                        | _ -> failwithf "collecting attribute parts failure" // should not happen
+                                                    <@ Attr.Dynamic n %(collect parts) @>
+                                        )
+                                        |> ExprArray
+                                    
+                                    let nodes = 
+                                        match e.Attribute(dataHole) with
+                                        | null ->
+                                            e.Nodes() |> Seq.collect (function
+                                                | :? XElement as n -> [ createNode false n ]
+                                                | :? XCData as n -> let v = n.Value in [ <@ Doc.Verbatim v @> ]
+                                                | :? XText as n ->
+                                                    getParts n.Value
+                                                    |> List.map (function
+                                                        | TextPart t -> <@ Doc.TextNode t @>
+                                                        | TextHole h -> <@ Doc.TextNode %(getSimpleHole h) @>
+                                                        | TextViewHole h -> <@ Doc.TextView %(getViewHole h) @>
+                                                    )
+                                                | _ -> []
+                                            ) 
+                                            |> ExprArray
+                                        | SpecialHole -> <@ [||] @>
+                                        | a -> <@ Array.ofSeq %(getSimpleHole a.Value) @>
+                    
+                                    if isRoot then 
+                                        <@ Doc.Concat %nodes @>
+                                    else
+                                        let n = e.Name.LocalName
+                                        let var a unchecked =
+                                            if n.ToLower() = "input" then
+                                                match e.Attribute(xn"type") with
+                                                | null -> <@ Doc.Input %attrs %(getVarHole a) :> Doc @>
+                                                | t ->
+                                                    match t.Value with
+                                                    | "checkbox" -> <@ Doc.CheckBox %attrs %(getVarHole a) :> _ @>
+                                                    | "number" ->
+                                                        if unchecked then
+                                                            <@ Doc.FloatInputUnchecked %attrs %(getVarHole a) :> _ @>
+                                                        else
+                                                            <@ Doc.FloatInput %attrs %(getVarHole a) :> _ @>
+                                                    | "password" -> <@ Doc.PasswordBox %attrs %(getVarHole a) :> _ @>
+                                                    | "text" | _ -> <@ Doc.Input %attrs %(getVarHole a) :> _ @>
+                                            elif n.ToLower() = "textarea" then
+                                                <@ Doc.InputArea %attrs %(getVarHole a) :> _ @>
+                                            elif n.ToLower() = "select" then
+                                                <@ Doc.Element "select"
+                                                    (Seq.append
+                                                        (Seq.singleton (Attr.Value %(getVarHole a)))
+                                                        %attrs)
+                                                    %nodes :> _ @>
+                                            else failwithf "data-var attribute \"%s\" on invalid element \"%s\"" a n
+                                        match e with
+                                        | NoVar -> <@ Doc.Element n %attrs %nodes :> _ @>
+                                        | Var a -> var a false
+                                        | VarUnchecked a -> var a true
+                    
+                                | SpecialHole as a ->
+                                    let elName = e.Name.LocalName
+                                    let attrValue = a.Value
+                                    <@ Doc.Element elName [|Attr.Create "data-replace" attrValue |] [||] :> _ @>
+                                | a -> <@ Doc.Concat %(getSimpleHole a.Value : Expr<seq<Doc>>) @>
+                            
+                            let mainExpr = t |> createNode true
+                    
+                            let pars = [ for KeyValue(name, h) in holes -> ProvidedParameter(name, h.ArgType) ]
+                    
+                            let code (args: Expr list) =
+                                let varMap = Dictionary()
+                                for KeyValue(name, hole), arg in Seq.zip holes args do
+                                    match hole with
+                                    | Hole.Simple ty ->
+                                        varMap.Add((name, ty), arg)
+                                    | Hole.Event ->
+                                        varMap.Add((name, EventTy), arg)
+                                    | Hole.View valTy ->
+                                        varMap.Add((name, ViewOf valTy), arg)
+                                    | Hole.IRef(valTy, hasView) ->
+                                        let irefTy = IRefOf valTy
+                                        varMap.Add((name, irefTy), arg)
+                                        if hasView then
+                                            varMap.Add((name, ViewOf valTy),
+                                                Expr.Call(arg,
+                                                    irefTy.GetProperty("View").GetGetMethod(),
+                                                    []))
+                                mainExpr.Substitute(fun v ->
+                                    match varMap.TryGetValue((v.Name, v.Type)) with
+                                    | true, e -> Some e
+                                    | false, _ -> None)
+                            
+                            ProvidedMethod("Doc", pars, typeof<Doc>, IsStaticMethod = true, InvokeCode = code)
                             |> toTy.AddMember
-
-                    for name, e in innerTemplates do
-                        ProvidedTypeDefinition(name, None) |>! addTemplateMethod e |> ty.AddMember
-
-                    ty |>! addTemplateMethod xml
-                | _ -> failwith "Unexpected parameter values")
-
+                            if isSingleElt then
+                                ProvidedMethod("Elt", pars, typeof<Elt>, IsStaticMethod = true,
+                                    InvokeCode = fun args -> <@@ (%%code args : Doc) :?> Elt @@>)
+                                |> toTy.AddMember
+                    
+                        for name, e in innerTemplates do
+                            ProvidedTypeDefinition(name, None) |>! addTemplateMethod e |> ty.AddMember
+                    
+                        ty |>! addTemplateMethod xml
+                    | _ -> failwith "Unexpected parameter values")
+                cache.GetOrAdd (typename, value))
         this.AddNamespace(rootNamespace, [ templateTy ])
 
 [<TypeProviderAssembly>]

--- a/WebSharper.UI.Next.Templating/WebSharper.UI.Next.Templating.fsproj
+++ b/WebSharper.UI.Next.Templating/WebSharper.UI.Next.Templating.fsproj
@@ -32,4 +32,7 @@
     <Compile Include="ProvidedTypes.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Runtime.Caching" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Before: when you change anything in a file where the TP is used or when you change the watching *.html file, `ProvidedTypeDefinition` is recreated 5 times in a row. Now it's recreated once.