### PR TITLE
Allow updating elements inserted by outside libraries

### DIFF
--- a/WebSharper.UI.Next.Templating.Tests/template.html
+++ b/WebSharper.UI.Next.Templating.Tests/template.html
@@ -32,6 +32,12 @@
     <div ws-replace="LeaveThisEmpty"></div>
     <p>Test Doc.X controls:</p>
     <div ws-replace="ControlTests"></div>
+    <p>Test EltUpdater</p>
+    <button ws-onclick="AddDiv">Add div</button>
+    <button ws-onclick="RemoveUpdater">Remove updater</button>
+    <button ws-onclick="ReAddUpdater">Readd updater</button>
+    <button ws-onclick="IncrEltUpdaterTest">Increase counter</button>
+    <div ws-replace="EltUpdaterTest"></div>
     <p>Here's some SVG:</p>
     <svg width="250" height="250">
         <rect x="25" y="25" width="200" height="200" fill="lime" stroke-width="4" stroke="pink" />

--- a/WebSharper.UI.Next/Doc.Client.fs
+++ b/WebSharper.UI.Next/Doc.Client.fs
@@ -67,6 +67,7 @@ type EltUpdater =
 
     member this.AddUpdated(doc: Elt) = ()
     member this.RemoveUpdated(doc: Elt) = ()
+    member this.RemoveAllUpdated() = ()
 
 [<JavaScript; Name "WebSharper.UI.Next.Docs">]
 module Docs =
@@ -1383,6 +1384,10 @@ and [<JavaScript; Proxy(typeof<EltUpdater>)>]
                     | _ -> true
                 )                
         | _ -> failwith "DocUpdater.RemoveUpdated expects a single element node"
+
+    member this.RemoveAllUpdated() =
+        treeNode.Holes <- [||]
+        holeUpdates.Value <- [||]
 
 [<AutoOpen; JavaScript>]
 module EltExtensions =

--- a/WebSharper.UI.Next/Doc.Client.fs
+++ b/WebSharper.UI.Next/Doc.Client.fs
@@ -62,6 +62,12 @@ and DocTreeNode =
         mutable Render : option<Dom.Element -> unit>
     }
 
+type EltUpdater =
+    inherit Elt
+
+    member this.AddUpdated(doc: Elt) = ()
+    member this.RemoveUpdated(doc: Elt) = ()
+
 [<JavaScript; Name "WebSharper.UI.Next.Docs">]
 module Docs =
 
@@ -95,7 +101,7 @@ module Docs =
                 | TextDoc t -> q.Enqueue (t.Text :> Node)
                 | TreeDoc t -> Array.iter q.Enqueue t.Els
             loop node.Children
-            DomNodes (q.ToArray())
+            DomNodes (Array.ofSeqNonCopying q)
 
         /// Set difference - currently only using equality O(N^2).
         /// Can do better? Can store <hash> data on every node?
@@ -238,7 +244,7 @@ module Docs =
                 | TreeDoc t -> t.Holes |> Array.iter loop
                 | _ -> ()
             loop doc
-            NodeSet (HashSet (q.ToArray()))
+            NodeSet (HashSet q)
 
         /// Set difference.
         static member Except (NodeSet excluded) (NodeSet included) =
@@ -1254,6 +1260,22 @@ and [<JavaScript; Proxy(typeof<Elt>); Name "WebSharper.UI.Next.Elt">]
         rvUpdates.Value <- View.Const()
         while (elt.HasChildNodes()) do elt.RemoveChild(elt.FirstChild) |> ignore
 
+    [<JavaScript>]
+    member this.ToUpdater() =
+        let docTreeNode : DocTreeNode =
+            match docNode with
+            | ElemDoc e ->
+                {
+                    Els = [| elt |]
+                    Holes = [| docNode |]
+                    Attrs = [||]
+                    Render = None
+                }
+            | TreeDoc e -> e
+            | _ -> failwith "Invalid docNode in Elt"
+
+        EltUpdater'(docTreeNode, updates, elt, rvUpdates, Var.Create [||])
+
     [<Name "Html">]
     member this.Html'() : string =
         elt?outerHTML
@@ -1327,6 +1349,40 @@ and [<JavaScript; Proxy(typeof<Elt>); Name "WebSharper.UI.Next.Elt">]
     [<Name "SetStyle">]
     member this.SetStyle'(style: string, value: string) =
         elt?style?(style) <- value
+                                                                  
+and [<JavaScript; Proxy(typeof<EltUpdater>)>] 
+    private EltUpdater'(treeNode : DocTreeNode, updates, elt, rvUpdates: Var<View<unit>>, holeUpdates: Var<(int * View<unit>)[]>) =
+    inherit Elt'(
+        TreeDoc treeNode, 
+        View.Map2Unit updates (holeUpdates.View |> View.BindInner (Array.map snd >> Array.TreeReduce (View.Const ()) View.Map2Unit)),
+        elt, rvUpdates)
+
+    member this.AddUpdated(doc: Elt) =
+        let d = As<Elt'> doc
+        match d.DocNode with
+        | ElemDoc e ->
+            treeNode.Holes.JS.Push(d.DocNode) |> ignore
+            let hu = holeUpdates.Value
+            hu.JS.Push ((e.ElKey, d.Updates)) |> ignore
+            holeUpdates.Value <- hu
+        | _ -> failwith "DocUpdater.AddUpdated expects a single element node"
+
+    member this.RemoveUpdated(doc: Elt) =
+        let d = As<Elt'> doc
+        match d.DocNode with
+        | ElemDoc e ->
+            let k = e.ElKey
+            treeNode.Holes <-
+                treeNode.Holes |> Array.filter (function
+                    | ElemDoc h when h.ElKey = k -> false
+                    | _ -> true
+                )
+            holeUpdates.Value <-
+                holeUpdates.Value |> Array.filter (function
+                    | uk, _ when uk = k -> false
+                    | _ -> true
+                )                
+        | _ -> failwith "DocUpdater.RemoveUpdated expects a single element node"
 
 [<AutoOpen; JavaScript>]
 module EltExtensions =
@@ -1469,6 +1525,9 @@ module Doc =
 
     [<Inline>]
     let ConvertSeqBy k f (v: View<seq<_>>) = BindSeqCachedViewBy k f v
+
+    [<Inline>]
+    let ToUpdater (e: Elt) = As<EltUpdater>((As<Elt'> e).ToUpdater() )
 
   // Form helpers ---------------------------------------------------------------
 
@@ -1626,6 +1685,10 @@ type DocExtensions =
     [<Extension; Inline>]
     static member Run(doc: Doc, elt: Dom.Element) =
         Doc'.Run elt (As<Doc'> doc)
+
+    [<Extension; Inline>]
+    static member ToUpdater(elt:Elt) =
+        As<EltUpdater> ((As<Elt'> elt).ToUpdater())
 
     [<Extension; Inline>]
     static member Append(this: Elt, doc: Doc) =

--- a/WebSharper.UI.Next/Doc.Client.fsi
+++ b/WebSharper.UI.Next/Doc.Client.fsi
@@ -46,6 +46,16 @@ module EltExtensions =
         /// Get or set the element's text content.
         member Text : string with get, set
 
+[<Class>]
+type EltUpdater =
+    inherit Elt
+
+    /// Subscribes an element inserted by outside DOM changes to be updated with this element
+    member AddUpdated : Elt -> unit
+    
+    /// Desubscribes an element added by AddUpdated
+    member RemoveUpdated : Elt -> unit
+
 // Extension methods
 [<Extension; Sealed>]
 type DocExtensions =
@@ -251,6 +261,10 @@ type DocExtensions =
     /// Sets an inline style.
     [<Extension>]
     static member SetStyle : Elt * name: string * value: string -> unit
+
+    /// Creates a wrapper that allows subscribing elements for DOM syncronization inserted through other means than UI.Next combinators.
+    [<Extension>]
+    static member ToUpdater : Elt -> EltUpdater
 
     // {{ event
     /// Add a handler for the event "abort".
@@ -1268,4 +1282,7 @@ module Doc =
     /// Radio button.
     val Radio : seq<Attr> -> 'T -> IRef<'T> -> Elt
         when 'T : equality
+
+    /// Creates a wrapper that allows subscribing elements for DOM syncronization inserted through other means than UI.Next combinators.
+    val ToUpdater : Elt -> EltUpdater
 

--- a/WebSharper.UI.Next/Doc.Client.fsi
+++ b/WebSharper.UI.Next/Doc.Client.fsi
@@ -56,6 +56,9 @@ type EltUpdater =
     /// Desubscribes an element added by AddUpdated
     member RemoveUpdated : Elt -> unit
 
+    /// Desubscribes all elements added by AddUpdated
+    member RemoveAllUpdated : unit -> unit
+
 // Extension methods
 [<Extension; Sealed>]
 type DocExtensions =


### PR DESCRIPTION
If you create an `Elt` and pass its `Dom` to an outside library that inserts it into the DOM, the element will be empty and not reacting, because its updater view is not tied to a root running synchronization.

The solution here is a small API, allowing to create an `EltUpdater` value from an `Elt` that reuses support for  how new templating engine can combine update view from holes, exposing `AddUpdater`/`RemoveUpdater`/`RemoveAllUpdaters` methods to alert UI.Next reactive system imperatively of changes done with outside libraries.

See test, it allows deconnecting updaters to show how without it elements are not reacting.